### PR TITLE
fix result returned empty result list by adding result to function call

### DIFF
--- a/automation_api_scripts/migrate_connections.py
+++ b/automation_api_scripts/migrate_connections.py
@@ -15,14 +15,15 @@ class ConnectionData:
     target_resource: str
 
 
-def _recursive_get_connections(children_resources: List[ResourceInfo]):
+def _recursive_get_connections(children_resources: List[ResourceInfo], result: List=None):
     """
     recursively get connections. No child resources is the base case
     :param list[ResourceInfo] children_resources:
     :param connections_list:
     :return:
     """
-    result = []
+    result = result if result else []
+
     for resource in children_resources:
         connections = resource.Connections
         children = resource.ChildResources
@@ -31,7 +32,7 @@ def _recursive_get_connections(children_resources: List[ResourceInfo]):
                 for connection in connections:
                     result.append(ConnectionData(resource.Name, connection.FullPath))
         else:
-            _recursive_get_connections(children)
+            _recursive_get_connections(children, result)
     return result
 
 


### PR DESCRIPTION
This is an in function call fix.
When ever '_recursive_get_connections' function is call a list should be passed with it, if list doesn't passed a new list will be initiated within the function (Line: 25)

Note: I'm unable to test this fix and encourage you to use the global list fix since i was able to check it on my environments.

Changes:
1. Line: 18 - Adding 'Result' to function call with default value None. 
2. Line: 25 - Result list comprehension.
3. Line 35 - When recursive call takes place - now the call from within the function will pass current and updated list.
